### PR TITLE
fix: Handle accented characters for StringUtility

### DIFF
--- a/src/Zephyrus/Utilities/StringUtility.php
+++ b/src/Zephyrus/Utilities/StringUtility.php
@@ -7,8 +7,8 @@ class StringUtility
         if (is_null($string)) {
             return "";
         }
-        return (strlen($string) > $length)
-            ? substr($string, 0, $length) . "..."
+        return (mb_strlen($string) > $length)
+            ? mb_substr($string, 0, $length) . "..."
             : $string;
     }
 


### PR DESCRIPTION
The StringUtility class was using `substr` and `strlen` functions which were not handling the accented characters correctly when the substr was removing one of the X bytes of a multibyte character. 

I have replaced the functions to use the multibyte version (`mb_substr` and `mb_strlen`) to fix the issue.