### PR TITLE
Improvement for Models manipulation with the Form

### DIFF
--- a/src/Zephyrus/Application/Form.php
+++ b/src/Zephyrus/Application/Form.php
@@ -1,6 +1,9 @@
-<?php namespace Zephyrus\Application;
+<?php
+
+namespace Zephyrus\Application;
 
 use stdClass;
+use Zephyrus\Core\Entity\Entity;
 
 class Form
 {
@@ -290,6 +293,66 @@ class Form
         }
         return (object) $objectProperties;
     }
+
+    /**
+     * Updates the given entity using the form fields that match entity's properties.
+     *
+     * @param object $entity
+     * @param array $ignoreFields
+     */
+    public function updateEntity(Entity $entity, array $ignoreFields = []): Entity
+    {
+        $formData = $this->getFields();
+        $reflection = new \ReflectionClass($entity);
+
+        foreach ($formData as $key => $value) {
+            if (in_array($key, $ignoreFields)) {
+                continue;
+            }
+
+            if ($reflection->hasProperty($key)) {
+                $property = $reflection->getProperty($key);
+                if ($property->isPublic()) {
+                    $entity->$key = $value;
+                }
+            }
+        }
+
+        return $entity;
+    }
+
+
+    /**
+     * Builds a new entity of the given class name using the form fields.
+     * Fields not matching properties will be ignored. Fields not present will be null.
+     *
+     * @param string $className
+     * @param array $ignoreFields
+     * @return object
+     */
+    public function buildEntity(string $className, array $ignoreFields = []): Entity
+    {
+        /** @var Entity $entity */
+        $entity = $className::build();
+        $formData = $this->getFields();
+        $reflection = new \ReflectionClass($entity);
+
+        foreach ($formData as $key => $value) {
+            if (in_array($key, $ignoreFields)) {
+                continue;
+            }
+
+            if ($reflection->hasProperty($key)) {
+                $property = $reflection->getProperty($key);
+                if ($property->isPublic()) {
+                    $entity->$key = $value;
+                }
+            }
+        }
+
+        return $entity;
+    }
+
 
     private static function flattenArray(array $array, $prefix = ''): array
     {

--- a/src/Zephyrus/Application/Form.php
+++ b/src/Zephyrus/Application/Form.php
@@ -312,9 +312,8 @@ class Form
 
             if ($reflection->hasProperty($key)) {
                 $property = $reflection->getProperty($key);
-                if ($property->isPublic()) {
-                    $entity->$key = $value;
-                }
+                $property->setAccessible(true);
+                $entity->$key = $value;
             }
         }
 
@@ -344,9 +343,8 @@ class Form
 
             if ($reflection->hasProperty($key)) {
                 $property = $reflection->getProperty($key);
-                if ($property->isPublic()) {
-                    $entity->$key = $value;
-                }
+                $property->setAccessible(true);
+                $entity->$key = $value;
             }
         }
 


### PR DESCRIPTION
# 🚀 Add `buildEntity` and `updateEntity` Methods to `Form` Class

## Summary

This PR introduces two new functions to `Zephyrus/Application/Form` class : 

- `buildEntity(string $className, array $ignoreFields = []): Entity`
- `updateEntity(object $entity, array $ignoreFields = []): Entity`

These methods enable automatic **mapping of form data into entities**, reducing boilerplate code and streamlining entity construction and updates from form submissions.

## Motivation 

In many use cases, particularly in CRUD-based applications, developers will need to : 

1. Populate an entity from form fields (e.g. `POST` data)
2. Update an existing entity instance with new form values
3. Avoid repetitive and error-prone manual property assignments.

By leveraging the fact that our entities extend a base `Entity` class, we can automate this process in a clean and efficient way.

## Features

### ✅ `buildEntity(...)`

Creates a new entity instance from the form fields, ignoring fields that don’t match any property.

```php
$book = $form->buildEntity(Book::class);
```

- Skips unknown fields
- Allows optional $ignoreFields to exclude specific fields from mapping
- Assumes entity defines a static build() method (which is enforced via inheritance)

### ✅ `updateEntity(...)`

Updates an existing entity with the current form fields.

```php
$book = $form->updateEntity($book);
```

- Updates matching properties only
- Respects $ignoreFields
- Returns the modified entity for conveniance

It is also important to note that those change are `NOT` breaking changes and `Zephyrus/Application/Form` class is still fully backward-compatible. 

