### PR TITLE
CSRF Session Mode for Multi-Window Support and IDS Flexibility (code-arena need)

### DIFF
--- a/src/Zephyrus/Core/Configuration/Security/CsrfConfiguration.php
+++ b/src/Zephyrus/Core/Configuration/Security/CsrfConfiguration.php
@@ -5,12 +5,23 @@ use Zephyrus\Core\Configuration\Configuration;
 
 class CsrfConfiguration extends Configuration
 {
+    public const MODE_FORM = 'form';
+    public const MODE_SESSION = 'session';
+
     public const array DEFAULT_CONFIGURATIONS = [
         'enabled' => true, // Enable the CSRF mitigation feature
+        'mode' => self::MODE_FORM, // Defines the mitigation mode (form = strict per form token, session = single per session token)
         'html_integration_enabled' => true, // Automatically insert needed HTML into forms
         'guard_methods' => ['POST', 'PUT', 'DELETE', 'PATCH'], // List of guarded methods
         'exceptions' => [] // List of route exceptions (e.g. ['\/test.*'] meaning all routes beginning with /test)
     ];
+
+    /**
+     * Defines the mitigation mode (form = strict per form token, session = single per session token).
+     *
+     * @var string
+     */
+    private string $mode = self::MODE_FORM;
 
     /**
      * Determines the HTTP request methods that should be secured by the CSRF mitigation. It implies that for EVERY
@@ -49,6 +60,7 @@ class CsrfConfiguration extends Configuration
     {
         parent::__construct($configurations);
         $this->initializeEnabled();
+        $this->initializeMode();
         $this->initializeAutomaticHtmlIntegration();
         $this->initializeGuardedMethods();
         $this->initializeExceptions();
@@ -57,6 +69,11 @@ class CsrfConfiguration extends Configuration
     public function isEnabled(): bool
     {
         return $this->enabled;
+    }
+
+    public function getMode(): string
+    {
+        return $this->mode;
     }
 
     /**
@@ -84,6 +101,17 @@ class CsrfConfiguration extends Configuration
         $this->enabled = (bool) ((isset($this->configurations['enabled']))
             ? $this->configurations['enabled']
             : self::DEFAULT_CONFIGURATIONS['enabled']);
+    }
+
+    private function initializeMode(): void
+    {
+        $this->mode = (isset($this->configurations['mode']))
+            ? $this->configurations['mode']
+            : self::DEFAULT_CONFIGURATIONS['mode'];
+
+        if (!in_array($this->mode, [self::MODE_FORM, self::MODE_SESSION])) {
+            throw new RuntimeException("CSRF mode is invalid. Must be one of the following values: " . self::MODE_FORM . ", " . self::MODE_SESSION . ".");
+        }
     }
 
     private function initializeAutomaticHtmlIntegration(): void

--- a/src/Zephyrus/Core/Configuration/Security/IdsConfiguration.php
+++ b/src/Zephyrus/Core/Configuration/Security/IdsConfiguration.php
@@ -7,6 +7,7 @@ class IdsConfiguration extends Configuration
 {
     public const array DEFAULT_CONFIGURATIONS = [
         'enabled' => false, // Enable the intrusion detection feature
+        'cached' => true, // Uses the APCu caching for the IDS rules
         'custom_file' => null, // Change the default rule file
         'impact_threshold' => 0, // Minimum impact to be considered to throw an exception (default is any detection)
         'monitor_cookies' => true, // Verifies the content of request cookies
@@ -15,6 +16,7 @@ class IdsConfiguration extends Configuration
     ];
 
     private bool $enabled;
+    private bool $cached;
     private int $impactThreshold;
     private array $exceptions;
     private bool $includeCookiesMonitoring;
@@ -25,6 +27,7 @@ class IdsConfiguration extends Configuration
     {
         parent::__construct($configurations);
         $this->initializeEnabled();
+        $this->initializeCached();
         $this->initializeImpactThreshold();
         $this->initializeExceptions();
         $this->initializeCookieMonitoring();
@@ -35,6 +38,11 @@ class IdsConfiguration extends Configuration
     public function isEnabled(): bool
     {
         return $this->enabled;
+    }
+
+    public function isCached(): bool
+    {
+        return $this->cached;
     }
 
     public function getImpactThreshold(): int
@@ -67,6 +75,13 @@ class IdsConfiguration extends Configuration
         $this->enabled = (bool) ((isset($this->configurations['enabled']))
             ? $this->configurations['enabled']
             : self::DEFAULT_CONFIGURATIONS['enabled']);
+    }
+
+    private function initializeCached(): void
+    {
+        $this->cached = (bool) ((isset($this->configurations['cached']))
+            ? $this->configurations['cached']
+            : self::DEFAULT_CONFIGURATIONS['cached']);
     }
 
     private function initializeImpactThreshold(): void

--- a/src/Zephyrus/Security/CsrfGuard.php
+++ b/src/Zephyrus/Security/CsrfGuard.php
@@ -21,8 +21,11 @@ class CsrfGuard
     private ?Request $request;
     private CsrfConfiguration $configuration;
 
-    public static function generate(): string
+    public static function generate(string $mode = CsrfConfiguration::MODE_FORM): string
     {
+        if ($mode === CsrfConfiguration::MODE_SESSION) {
+            return self::getSessionToken();
+        }
         $name = self::generateFormName();
         $token = self::generateToken($name);
         return $name . '$' . $token;
@@ -64,7 +67,7 @@ class CsrfGuard
      */
     public function generateHiddenFields(): string
     {
-        $value = self::generate();
+        $value = self::generate($this->configuration->getMode());
         return '<input type="hidden" name="' . self::REQUEST_TOKEN_VALUE . '" value="' . $value . '" />';
     }
 
@@ -195,6 +198,22 @@ class CsrfGuard
     }
 
     /**
+     * Generates and stores in the current session a cryptographically random token that shall be validated during the
+     * run method. The token is unique per session and does not expire after validation.
+     *
+     * @return string
+     */
+    private static function getSessionToken(): string
+    {
+        $csrfData = Session::get('__CSRF_TOKEN', []);
+        if (!isset($csrfData['CSRFGuard_Session'])) {
+            $csrfData['CSRFGuard_Session'] = Cryptography::randomString(self::TOKEN_LENGTH);
+            Session::set('__CSRF_TOKEN', $csrfData);
+        }
+        return 'CSRFGuard_Session$' . $csrfData['CSRFGuard_Session'];
+    }
+
+    /**
      * Returns a random name to be used for a form csrf token.
      *
      * @return string
@@ -206,7 +225,7 @@ class CsrfGuard
 
     /**
      * Validates the given token with the one stored for the specified form name. Once validated, good or not, the token
-     * is removed from the session.
+     * is removed from the session (unless in session mode where it persists).
      *
      * @param string $formName
      * @param string $token
@@ -217,7 +236,8 @@ class CsrfGuard
         $sortedCsrf = $this->getStoredCsrfToken($formName);
         if (!is_null($sortedCsrf)) {
             $csrfData = Session::get('__CSRF_TOKEN', []);
-            if (is_null($this->request->getHeader('CSRF_KEEP_ALIVE'))
+            if ($this->configuration->getMode() !== CsrfConfiguration::MODE_SESSION
+                && is_null($this->request->getHeader('CSRF_KEEP_ALIVE'))
                 && is_null($this->request->getParameter('CSRF_KEEP_ALIVE'))) {
                 $csrfData[$formName] = '';
                 Session::set('__CSRF_TOKEN', $csrfData);

--- a/src/Zephyrus/Security/IntrusionDetection.php
+++ b/src/Zephyrus/Security/IntrusionDetection.php
@@ -22,6 +22,24 @@ class IntrusionDetection
         $this->initializeMonitor();
     }
 
+    private function initializeMonitor(): void
+    {
+        $loader = new IntrusionRuleLoader($this->configuration->getCustomFile());
+        $intrusionRules = [];
+        if ($this->configuration->isCached()) {
+            $cache = new IntrusionCache();
+            $intrusionRules = $cache->getRules();
+            if (empty($intrusionRules)) {
+                $intrusionRules = $loader->loadFromFile();
+                $cache->cache($intrusionRules);
+            }
+        }
+        if (empty($intrusionRules)) {
+            $intrusionRules = $loader->loadFromFile();
+        }
+        $this->monitor = new IntrusionMonitor($intrusionRules);
+    }
+
     /**
      * Execute the intrusion detection analysis using the specified monitored inputs. If an intrusion is detected, the
      * method will throw an exception.
@@ -35,6 +53,22 @@ class IntrusionDetection
         if ($this->report->getImpact() > $this->configuration->getImpactThreshold()) {
             throw new IntrusionDetectionException($this->report);
         }
+    }
+
+    /**
+     * Prepares the request parameters to be verified by the IDS monitor. Will automatically include all request data
+     * and cookies if included in configurations.
+     *
+     * @return array
+     */
+    private function getMonitoringInputs(): array
+    {
+        return [
+            'parameters' => $this->request->getParameters(),
+            'arguments' => $this->request->getArguments(),
+            'cookies' => ($this->configuration->isCookieMonitoring()) ? $this->request->getCookieJar()->getAll() : [],
+            'url' => ($this->configuration->isUrlMonitoring()) ? ['requested_url' => $this->request->getRequestedUrl()] : [],
+        ];
     }
 
     /**
@@ -57,33 +91,5 @@ class IntrusionDetection
     public function getReport(): ?IntrusionReport
     {
         return $this->report;
-    }
-
-    private function initializeMonitor(): void
-    {
-        $loader = new IntrusionRuleLoader($this->configuration->getCustomFile());
-        $cache = new IntrusionCache();
-        $intrusionRules = $cache->getRules();
-        if (empty($intrusionRules)) {
-            $intrusionRules = $loader->loadFromFile();
-            $cache->cache($intrusionRules);
-        }
-        $this->monitor = new IntrusionMonitor($intrusionRules);
-    }
-
-    /**
-     * Prepares the request parameters to be verified by the IDS monitor. Will automatically include all request data
-     * and cookies if included in configurations.
-     *
-     * @return array
-     */
-    private function getMonitoringInputs(): array
-    {
-        return [
-            'parameters' => $this->request->getParameters(),
-            'arguments' => $this->request->getArguments(),
-            'cookies' => ($this->configuration->isCookieMonitoring()) ? $this->request->getCookieJar()->getAll() : [],
-            'url' => ($this->configuration->isUrlMonitoring()) ? ['requested_url' => $this->request->getRequestedUrl()] : [],
-        ];
     }
 }

--- a/tests/Zephyrus/Security/CsrfGuardSessionModeTest.php
+++ b/tests/Zephyrus/Security/CsrfGuardSessionModeTest.php
@@ -1,0 +1,68 @@
+<?php namespace Zephyrus\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use Zephyrus\Core\Configuration\Security\CsrfConfiguration;
+use Zephyrus\Security\CsrfGuard;
+use Zephyrus\Tests\RequestUtility;
+
+class CsrfGuardSessionModeTest extends TestCase
+{
+    public function testSessionModeGeneration()
+    {
+        $req = RequestUtility::get("/test");
+        $csrf = new CsrfGuard($req, new CsrfConfiguration([
+            'mode' => CsrfConfiguration::MODE_SESSION
+        ]));
+
+        $result1 = $csrf->generateHiddenFields();
+        $result2 = $csrf->generateHiddenFields();
+
+        $this->assertEquals($result1, $result2, "Tokens should be identical in session mode");
+        $this->assertTrue($this->hasHiddenFields($result1));
+    }
+
+    private function hasHiddenFields($html): bool
+    {
+        return (bool)preg_match("/<input type=\"hidden\" name=\"CSRFToken\" value=\"CSRFGuard_Session\\$[0-9a-zA-Z]+\" \/>/", $html);
+    }
+
+    public function testSessionModeValidation()
+    {
+        $req = RequestUtility::get("/test");
+        $csrf = new CsrfGuard($req, new CsrfConfiguration([
+            'mode' => CsrfConfiguration::MODE_SESSION,
+            'guard_methods' => ['DELETE']
+        ]));
+
+        // Generate token
+        $output = $csrf->generateHiddenFields();
+        $fields = $this->getHiddenFieldValues($output);
+        $name = $fields[1];
+        $value = $fields[2];
+
+        // First validation
+        $req = RequestUtility::delete("/test", 'CSRFToken=' . $name . '$' . $value);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration([
+            'mode' => CsrfConfiguration::MODE_SESSION,
+            'guard_methods' => ['DELETE']
+        ]));
+        $csrf->run();
+
+        // Second validation (should still work as token is not removed)
+        $req = RequestUtility::delete("/test", 'CSRFToken=' . $name . '$' . $value);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration([
+            'mode' => CsrfConfiguration::MODE_SESSION,
+            'guard_methods' => ['DELETE']
+        ]));
+        $csrf->run();
+
+        $this->assertTrue(true); // Should reach here without exception
+    }
+
+    private function getHiddenFieldValues($html): array
+    {
+        $output = [];
+        preg_match("/<input type=\"hidden\" name=\"CSRFToken\" value=\"(CSRFGuard_Session)\\$([0-9a-zA-Z]+)\" \/>/", $html, $output);
+        return $output;
+    }
+}

--- a/tests/Zephyrus/Security/CsrfGuardTest.php
+++ b/tests/Zephyrus/Security/CsrfGuardTest.php
@@ -2,6 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Zephyrus\Core\Configuration\Security\CsrfConfiguration;
 use Zephyrus\Core\Session;
 use Zephyrus\Exceptions\Security\InvalidCsrfException;
 use Zephyrus\Exceptions\Security\MissingCsrfException;
@@ -14,7 +15,7 @@ class CsrfGuardTest extends TestCase
     public function testHiddenFields()
     {
         $req = RequestUtility::get("/test");
-        $csrf = new CsrfGuard($req);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration());
         $result = $csrf->generateHiddenFields();
         self::assertTrue($this->hasHiddenFields($result));
         self::assertTrue($csrf->isHtmlIntegrationEnabled());
@@ -24,9 +25,9 @@ class CsrfGuardTest extends TestCase
     public function testGuard()
     {
         $req = RequestUtility::get("/test");
-        $csrf = new CsrfGuard($req, [
+        $csrf = new CsrfGuard($req, new CsrfConfiguration([
             'guard_methods' => ['DELETE']
-        ]);
+        ]));
         $csrf->run();
         $output = $csrf->generateHiddenFields();
         $fields = $this->getHiddenFieldValues($output);
@@ -34,9 +35,9 @@ class CsrfGuardTest extends TestCase
         $value = $fields[2];
 
         $req = RequestUtility::delete("/test", 'CSRFToken=' . $name . '$' . $value);
-        $csrf = new CsrfGuard($req, [
+        $csrf = new CsrfGuard($req, new CsrfConfiguration([
             'guard_methods' => ['DELETE']
-        ]);
+        ]));
         $csrf->run();
         self::assertEquals($name . '$' . $value, $req->getParameter('CSRFToken'));
     }
@@ -44,7 +45,7 @@ class CsrfGuardTest extends TestCase
     public function testFormInject()
     {
         $req = RequestUtility::post("/test");
-        $csrf = new CsrfGuard($req);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration());
         $html = '<html><body><form action="test" method="get"><input type="text" name="test" /></form></body>';
         $result = $csrf->injectForms($html);
         self::assertTrue($this->hasHiddenFields($result));
@@ -53,7 +54,7 @@ class CsrfGuardTest extends TestCase
     public function testFormInjectExclusion()
     {
         $req = RequestUtility::post("/test");
-        $csrf = new CsrfGuard($req);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration());
         $html = '<html><body><form nocsrf="true" action="test" method="get"><input type="text" name="test" /></form></body>';
         $result = $csrf->injectForms($html);
         self::assertEquals($html, $result);
@@ -62,11 +63,11 @@ class CsrfGuardTest extends TestCase
     public function testProperties()
     {
         $req = RequestUtility::post("/test");
-        $csrf = new CsrfGuard($req, [
+        $csrf = new CsrfGuard($req, new CsrfConfiguration([
             'enabled' => false,
             'guard_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
             'html_integration_enabled' => false
-        ]);
+        ]));
         self::assertFalse($csrf->isEnabled());
         self::assertFalse($csrf->isHtmlIntegrationEnabled());
         self::assertTrue($csrf->isDeleteSecured());
@@ -79,12 +80,12 @@ class CsrfGuardTest extends TestCase
     public function testRequestException()
     {
         $req = RequestUtility::post("/test");
-        $csrf = new CsrfGuard($req, [
+        $csrf = new CsrfGuard($req, new CsrfConfiguration([
             'enabled' => true,
             'guard_methods' => ['POST', 'PUT', 'PATCH', 'DELETE'],
             'html_integration_enabled' => true,
             'exceptions' => ['/test'] // Direct exception
-        ]);
+        ]));
         self::assertTrue($csrf->isPostSecured());
         $csrf->run();
         self::assertTrue(true); // if reach is ok
@@ -93,12 +94,12 @@ class CsrfGuardTest extends TestCase
     public function testRequestRegexException()
     {
         $req = RequestUtility::post("/test/toto");
-        $csrf = new CsrfGuard($req, [
+        $csrf = new CsrfGuard($req, new CsrfConfiguration([
             'enabled' => true,
             'guard_methods' => ['POST', 'PUT', 'PATCH', 'DELETE'],
             'html_integration_enabled' => true,
             'exceptions' => ['\/test.*'] // Regex to validate all route that begins with /test
-        ]);
+        ]));
         self::assertTrue($csrf->isPostSecured());
         $csrf->run();
         self::assertTrue(true); // if reach is ok
@@ -108,10 +109,10 @@ class CsrfGuardTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $req = RequestUtility::post("/test");
-        new CsrfGuard($req, [
+        new CsrfGuard($req, new CsrfConfiguration([
             'enabled' => true,
             'guard_methods' => ['GET', 'POST', 'PUT', 'OUPPPS', 'DELETE']
-        ]);
+        ]));
     }
 
     public function testGuardMissingException()
@@ -119,7 +120,7 @@ class CsrfGuardTest extends TestCase
         $this->expectException(MissingCsrfException::class);
         $this->expectExceptionMessage("ZEPHYRUS SECURITY: The submitted form is missing the needed CSRF tokens. The requested route [POST /test] is configured to proceed the CSRF mitigation. If you think this is not the case, you can add the route to the CSRF exceptions, use the 'nocsrf' attribute on the &lt;form&gt; or disable the feature.");
         $req = RequestUtility::buildFormRequest("/test", HttpMethod::POST);
-        $csrf = new CsrfGuard($req);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration());
         $csrf->run();
     }
 
@@ -127,14 +128,14 @@ class CsrfGuardTest extends TestCase
     {
         $this->expectException(InvalidCsrfException::class);
         $req = RequestUtility::put("/test", "CSRFToken=invalid");
-        $csrf = new CsrfGuard($req);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration());
         $csrf->run();
     }
 
     public function testGuardInvalidException()
     {
         $req = RequestUtility::put("/test", "CSRFToken=invalid");
-        $csrf = new CsrfGuard($req);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration());
         try {
             $csrf->run();
         } catch (InvalidCsrfException $e) {
@@ -147,7 +148,7 @@ class CsrfGuardTest extends TestCase
     {
         $this->expectException(InvalidCsrfException::class);
         $req = RequestUtility::patch("/test", "CSRFToken=invalid");
-        $csrf = new CsrfGuard($req);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration());
         $csrf->run();
     }
 
@@ -155,7 +156,7 @@ class CsrfGuardTest extends TestCase
     {
         $this->expectException(InvalidCsrfException::class);
         $req = RequestUtility::post("/test", "CSRFToken=invalid");
-        $csrf = new CsrfGuard($req);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration());
         $csrf->run();
     }
 
@@ -163,9 +164,9 @@ class CsrfGuardTest extends TestCase
     {
         $this->expectException(MissingCsrfException::class);
         $req = RequestUtility::get("/test");
-        $csrf = new CsrfGuard($req, [
+        $csrf = new CsrfGuard($req, new CsrfConfiguration([
             'guard_methods' => ['GET']
-        ]);
+        ]));
         $csrf->run();
     }
 
@@ -173,7 +174,7 @@ class CsrfGuardTest extends TestCase
     {
         $this->expectException(InvalidCsrfException::class);
         $req = RequestUtility::get("/test");
-        $csrf = new CsrfGuard($req);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration());
         $csrf->run();
         $output = $csrf->generateHiddenFields();
         $fields = $this->getHiddenFieldValues($output);
@@ -181,7 +182,7 @@ class CsrfGuardTest extends TestCase
         $value = $fields[2];
 
         $req = RequestUtility::delete("/test", "CSRFToken=" . $name . '$' . $value);
-        $csrf = new CsrfGuard($req);
+        $csrf = new CsrfGuard($req, new CsrfConfiguration());
         Session::remove('__CSRF_TOKEN');
         $csrf->run();
     }


### PR DESCRIPTION
# CSRF Session Mode for Multi-Window Support and IDS Flexibility (code-arena need)

## Description
The primary goal of this Pull Request is to provide support for **multi-window** by introducing a new CSRF session mode. It also improves framework portability by making the IDS caching optional.

### 1. CSRF Session Mode (Multi-Window Support)
The current "Per-Request" CSRF implementation in Zephyrus (a unique token for every form) creates issues. Opening multiple windows or sending concurrent AJAX requests often leads to token invalidation errors, making multi-window usage and window refresh hard (we need to force some timeouts, etc.).

This update introduces a `mode` parameter in the CSRF configuration:
*   **`form` mode (Default)**: Retains the current strict behavior.
*   **`session` mode**: Uses a stable, persistent token for the entire user session.
    *   **Purpose**: This is essential for applications requiring **multi-window support**. It allows users to work across multiple tabs and perform simultaneous background requests without synchronization issues.
    *   **Industry Standard**: This aligns Zephyrus with the default behavior of major frameworks like **Laravel** and **Symfony**, (this is what they do).

**Key Changes:**
*   `CsrfConfiguration.php`: Added mode constants and reading logic.
*   `CsrfGuard.php`: Implemented session-persistent token logic (`getSessionToken`) and updated validation.

### 2. IDS Portability (`cached` option)
Previously, the IDS strictly required the APCu extension for caching, causing fatal errors in environments where it was unavailable (my computer while running tests for exemple with composer).

*   Added a `cached` boolean option to the IDS configuration.
*   Setting it to `false` allows the IDS to run by loading rules directly from the source file, removing the mandatory APCu dependency for development and testing.

### 3. Unit Testing
*   Added `CsrfGuardSessionModeTest.php` to verify token persistence and reuse in session mode.
*   Updated `CsrfGuardTest.php` to fix constructor usage and ensure the test suite is working.

---

## Configuration

### How to enable session mode?
In your `config.yml`:
```yaml
security:
  csrf:
    enabled: true
    mode: "session" # Enables stable tokens across all forms
```

### How to run without APCu?
In your `config.yml`:
```yaml
security:
  ids:
    enabled: true
    cached: false # Disables APCu requirement
```

---
